### PR TITLE
feat(hexToNumber): add failing test showing that bad hex values are not invalid

### DIFF
--- a/src/deserialize/hexToNumber.test.ts
+++ b/src/deserialize/hexToNumber.test.ts
@@ -13,7 +13,7 @@ describe("hexToDate", () => {
     const fnumber = "0x878328";
     expect(hexToNumber(fnumber)).toEqual(8880936);
   });
-  it("can return a not-number for nothing", () => {
+  it("can return a NaN for empty parameter", () => {
         const fnumber = "";
         expect(hexToNumber(fnumber)).toEqual(NaN);
     });

--- a/src/deserialize/hexToNumber.test.ts
+++ b/src/deserialize/hexToNumber.test.ts
@@ -13,4 +13,12 @@ describe("hexToDate", () => {
     const fnumber = "0x878328";
     expect(hexToNumber(fnumber)).toEqual(8880936);
   });
+  it("can return a not-number for nothing", () => {
+        const fnumber = "";
+        expect(hexToNumber(fnumber)).toEqual(NaN);
+    });
+  it("should return NaN for bad input", () => {
+        const fnumber = "badnumber";
+        expect(hexToNumber(fnumber)).not.toEqual(2989);
+    });
 });


### PR DESCRIPTION
I expect `hexToNumber` (and other `hexTo<>` functions) to throw or return a `NaN` or empty value when given an invalid hex value as input.

Test added which shows that `hexToNumber("badnumber")` returns `2989` instead of somehow showing invalidity.